### PR TITLE
Sync cache hits added.

### DIFF
--- a/app/src/main/java/com/lighttigerxiv/simple/mp/compose/activities/main/ActivityMain.kt
+++ b/app/src/main/java/com/lighttigerxiv/simple/mp/compose/activities/main/ActivityMain.kt
@@ -5,7 +5,9 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Intent
 import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+import android.database.ContentObserver
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
 import android.widget.Toast
@@ -92,6 +94,20 @@ class MainActivity : ComponentActivity() {
 
             finish()
         }
+
+        //I'm clueless where to put it, but I'm guessing this code runs at the start and only once
+        val uri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+        val contentObserver = object : ContentObserver(null) {
+                override fun onChange(selfChange: Boolean, uri: Uri?) {
+                    super.onChange(selfChange, uri)
+                    if (uri != null) {
+                        //added, deleted, or modified
+                        //TODO: this must be handled and updates to UI called to save resources and avoid reloading/syncing
+                    }
+                }
+            }
+        //It's pretty expensive, so we should watchout not to spawn more than one as it's all that we need
+        applicationContext.contentResolver.registerContentObserver(uri, true, contentObserver)
 
         createNotificationChannels()
 

--- a/app/src/main/java/com/lighttigerxiv/simple/mp/compose/data/workers/SyncSongsWorker.kt
+++ b/app/src/main/java/com/lighttigerxiv/simple/mp/compose/data/workers/SyncSongsWorker.kt
@@ -33,115 +33,99 @@ class SyncSongsWorker(appContext: Context, params: WorkerParameters) : Coroutine
                 .setSilent(true)
 
             val cachedQueries = CacheQueries(getMongoRealm())
-            cachedQueries.clear()
 
-            val songs = ArrayList<Song>()
-            val artists = ArrayList<Artist>()
-            val albums = ArrayList<Album>()
+            val songs = cachedQueries.getSongs()
+            val artists = cachedQueries.getArtists()
+            val albums = cachedQueries.getAlbums()
             val uri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
-            var cursor = applicationContext.contentResolver.query(uri, null, null, null, null)
-            var totalSongsCount = 0
+
+            val cursor = applicationContext.contentResolver.query(uri, null, null, null, null)
+                ?: return@withContext Result.failure() //No mediastore rows found
+            val cachedSongIds = songs.map { it.id }.toHashSet()
+            val totalSongsCount = cursor.count
             var indexedSongsCount = 0
 
-            if (cursor != null) {
-                while (cursor.moveToNext()) {
-                    totalSongsCount += 1
-                }
-            }
-
-            cursor?.close()
-
-            cursor = applicationContext.contentResolver.query(uri, null, null, null, null)
-
-            if (cursor != null) {
-                while (cursor.moveToNext()) {
-
-                    try {
-
-                        val id = cursor.getLong(cursor.getColumnIndex(MediaStore.Audio.Media._ID))
-                        val songPath = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Media.DATA))
-
-                        val retriever = MediaMetadataRetriever()
-                        retriever.setDataSource(songPath)
-
-                        var title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
-                        var albumTitle = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM)
-                        val albumID = cursor.getLong(cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM_ID))
-                        var duration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
-                        var artistName = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST)
-                        val artistID = cursor.getLong(cursor.getColumnIndex(MediaStore.Audio.Media.ARTIST_ID))
-                        var genre = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_GENRE)
-                        val modificationDate = File(songPath).lastModified()
-
-
-                        if (title == null) {
-                            title = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Media.TITLE))
-                        }
-
-                        if (albumTitle == null) {
-                            albumTitle = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Albums.ALBUM))
-                        }
-
-                        if (duration == null) {
-                            duration = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Media.DURATION))
-                        }
-
-                        if (artistName == null) {
-                            artistName = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Artists.ARTIST))
-                        }
-
-                        if (!artists.any { it.id == artistID }) {
-
-                            val artist = Artist(
-                                artistID,
-                                artistName ?: "",
-                                null
-                            )
-
-                            artists.add(artist)
-
-                            cachedQueries.addArtist(artist)
-                        }
-
-                        if (!albums.any { it.id == albumID }) {
-
-                            val album = Album(
-                                albumID,
-                                albumTitle ?: "",
-                                null,
-                                artistID
-                            )
-
-                            albums.add(album)
-
-                            cachedQueries.addAlbum(album)
-                        }
-
-
-                        if (genre == null) genre = applicationContext.getString(R.string.Undefined)
-                        val year = cursor.getInt(cursor.getColumnIndex(MediaStore.Audio.Media.YEAR))
-
-                        if (title != null && duration != null && artistID != 0L && albumID != 0L) {
-
-                            val song = Song(id, songPath, title, albumID, duration.toInt(), artistID, year, genre, modificationDate)
-
-                            songs.add(song)
-
-                            cachedQueries.addSong(song)
-
-                            indexedSongsCount++
-
-                            notificationBuilder.setProgress(totalSongsCount, indexedSongsCount, false)
-                            notificationManager.notify(3, notificationBuilder.build())
-                        }
-
-                    } catch (e: Exception) {
-                        Log.e("Song Error", "Exception while getting song. Details -> ${e.message}")
+            while (cursor.moveToNext()) {
+                try {
+                    val id = cursor.getLong(cursor.getColumnIndex(MediaStore.Audio.Media._ID))
+                    if (cachedSongIds.contains(id)){ //cache hit or miss
+                        indexedSongsCount++
+                        continue
                     }
+
+                    val songPath = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Media.DATA))
+
+                    val retriever = MediaMetadataRetriever()
+                    retriever.setDataSource(songPath)
+
+                    var title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
+                    var albumTitle = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM)
+                    val albumID = cursor.getLong(cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM_ID))
+                    var duration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                    var artistName = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST)
+                    val artistID = cursor.getLong(cursor.getColumnIndex(MediaStore.Audio.Media.ARTIST_ID))
+                    var genre = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_GENRE)
+                    val modificationDate = File(songPath).lastModified()
+
+
+                    if (title == null) {
+                        title = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Media.TITLE))
+                    }
+
+                    if (albumTitle == null) {
+                        albumTitle = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Albums.ALBUM))
+                    }
+
+                    if (duration == null) {
+                        duration = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Media.DURATION))
+                    }
+
+                    if (artistName == null) {
+                        artistName = cursor.getString(cursor.getColumnIndex(MediaStore.Audio.Artists.ARTIST))
+                    }
+
+                    if (!artists.any { it.id == artistID }) {
+
+                        val artist = Artist(
+                            artistID,
+                            artistName ?: "",
+                            null
+                        )
+                        cachedQueries.addArtist(artist)
+                    }
+
+                    if (!albums.any { it.id == albumID }) {
+
+                        val album = Album(
+                            albumID,
+                            albumTitle ?: "",
+                            null,
+                            artistID
+                        )
+                        cachedQueries.addAlbum(album)
+                    }
+
+
+                    if (genre == null) genre = applicationContext.getString(R.string.Undefined)
+                    val year = cursor.getInt(cursor.getColumnIndex(MediaStore.Audio.Media.YEAR))
+
+                    if (title != null && duration != null && artistID != 0L && albumID != 0L) {
+
+                        val song = Song(id, songPath, title, albumID, duration.toInt(), artistID, year, genre, modificationDate)
+                        cachedQueries.addSong(song)
+
+                        indexedSongsCount++
+
+                        notificationBuilder.setProgress(totalSongsCount, indexedSongsCount, false)
+                        notificationManager.notify(3, notificationBuilder.build())
+                    }
+
+                } catch (e: Exception) {
+                    Log.e("Song Error", "Exception while getting song. Details -> ${e.message}")
                 }
             }
 
-            cursor?.close()
+            cursor.close()
 
             notificationManager.cancel(3)
 


### PR DESCRIPTION
**Disclaimer**: My first time reading and writing Kotlin code so I didn't go too deep as I'll just write useless trash regardless. _Exercise caution_! 
Reduced sync time once library is synced by using cache from DB with a song ID hashset which made a pretty big change on media libraries of significant size.

**TODO**: add observer to avoid unnecessary syncing.
I suggest using an observer. Example usage I've put it in main activity as I have to clue where it should be put and how to update UI, but I confirmed that it works as expected and reports changes to media store which will allow for real-time updates and  O(1) updating instead of O(n) time sync as done currently.